### PR TITLE
chore: make dependencies compatible with dart 3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,11 +6,11 @@ repository: https://gitlab.com/famedly/company/frontend/libraries/matrix_api_lit
 issues: https://gitlab.com/famedly/company/frontend/libraries/matrix_api_lite/-/issues
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
   enhanced_enum: ^0.2.4
-  http: ^0.13.0
+  http: ">=0.13.0 <2.0.0"
   mime: ^1.0.0
 
 dev_dependencies:
@@ -19,7 +19,7 @@ dev_dependencies:
   import_sorter: ^4.6.0
   lints: ^2.0.0
   test: ^1.14.4
- 
+
 dependency_overrides:
 # uncomment for local development
 #  matrix:


### PR DESCRIPTION
Specifically to allow us to get rid of the http dependency overrides.